### PR TITLE
Utilize versioned user-agent on request

### DIFF
--- a/src/core/Requestor.ts
+++ b/src/core/Requestor.ts
@@ -3,6 +3,7 @@ import { Constant } from "../struct/Constant";
 import { Cursors, Json, Mode } from "../types";
 import OcdlError from "../struct/OcdlError";
 import { CollectionId } from "../struct/Collection";
+import { LIB_VERSION } from "../version";
 
 interface FetchCollectionQuery {
   perPage?: number;
@@ -72,8 +73,11 @@ export class Requestor {
         ? Constant.OsuMirrorAltApiUrl
         : Constant.OsuMirrorApiUrl) + id.toString();
 
-    const res = await fetch(url, { method: "GET" });
-
+    const fetchOptions = {
+      headers: {'User-Agent': `osu-collector-dl/v${LIB_VERSION}`},
+      method: "GET",
+    }
+    const res = await fetch(url, fetchOptions);
     return res;
   }
 


### PR DESCRIPTION
Not a major change, just for better visibility inside Mino, we're still getting quite a few bans from people utilizing old versions, and it uses the generic "undici" UA from the lib.

Of course tested, all still works well:
![image](https://github.com/user-attachments/assets/48420919-d09a-4264-9c60-4d6a5bdf1716)
